### PR TITLE
Stable compilation and no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "include-dir-macro"
 version = "0.2.0"
 edition = "2018"
-authors = ["J. Cliff Dyer <jcd@sdf.org>"]
+authors = [
+  "J. Cliff Dyer <jcd@sdf.org>",
+  "Jonathan Klimt <jonathan.klimt@rwth-aachen.de>",
+]
 description = "Provides a macro to include a directory tree of files in the compiled binary"
 repository = "https://github.com/jcdyer/include-dir-macro"
 license = "Apache-2.0"
@@ -13,11 +16,11 @@ quote = "0.3"
 
 rocket = { version = "0.5", optional = true }
 tree_magic = { version = "0.2", optional = true }
+heapless = { version = "0.8.0", optional = true }
 
 [features]
 web = ["rocket", "tree_magic"]
-rocket = ["dep:rocket"]
-tree_magic = ["dep:tree_magic"]
+no_std = ["dep:heapless"]
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ license = "Apache-2.0"
 syn = "0.11"
 quote = "0.3"
 
-rocket = { version = "0.4", optional = true }
+rocket = { version = "0.5", optional = true }
 tree_magic = { version = "0.2", optional = true }
 
 [features]
 web = ["rocket", "tree_magic"]
+rocket = ["dep:rocket"]
+tree_magic = ["dep:tree_magic"]
 
 [lib]
 proc-macro = true

--- a/examples/poems.rs
+++ b/examples/poems.rs
@@ -18,7 +18,9 @@ fn main() {
     }
     let nightingale = Path::new("keats/ode-to-a-nightingale.txt");
     println!("{}", nightingale.to_string_lossy());
-    let nightingale_text = hashmap.get(nightingale)
-        .and_then(|entry| from_utf8(*entry).ok()).unwrap();
+    let nightingale_text = hashmap
+        .get(nightingale)
+        .and_then(|entry| from_utf8(*entry).ok())
+        .unwrap();
     println!("{}", nightingale_text);
 }

--- a/examples/poems.rs
+++ b/examples/poems.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 //! This uses the `include_dir!()` procedural macro.  When run, it prints out the
 //! names of all the files in examples/poems, and then prints the contents of
 //! one of the files in the directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,3 @@ fn impl_include_dir(args: Vec<TokenTree>) -> Result<quote::Tokens, &'static str>
         }
     })
 }
-
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,11 @@ extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 
+use proc_macro::TokenStream;
 use std::path::{Path, PathBuf};
 use std::str;
-use proc_macro::TokenStream;
 
-use syn::{Lit, StrStyle, Token, TokenTree, parse_token_trees};
-
+use syn::{parse_token_trees, Lit, StrStyle, Token, TokenTree};
 
 #[proc_macro]
 pub fn include_dir(input: TokenStream) -> TokenStream {
@@ -18,7 +17,6 @@ pub fn include_dir(input: TokenStream) -> TokenStream {
     let gen = impl_include_dir(args).unwrap();
     gen.parse().unwrap()
 }
-
 
 fn get_files<P: AsRef<Path>>(dir: P) -> Vec<PathBuf> {
     let mut files = vec![];
@@ -37,7 +35,6 @@ fn get_files<P: AsRef<Path>>(dir: P) -> Vec<PathBuf> {
     }
     files
 }
-
 
 fn path_to_str_literal<P: AsRef<Path>>(path: P) -> Token {
     Token::Literal(Lit::Str(
@@ -59,7 +56,6 @@ fn get_path_from_args(args: Vec<TokenTree>) -> Result<PathBuf, &'static str> {
         _ => Err("multiple trees"),
     }
 }
-
 
 fn impl_include_dir(args: Vec<TokenTree>) -> Result<quote::Tokens, &'static str> {
     let dir = get_path_from_args(args)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ fn get_files<P: AsRef<Path>>(dir: P) -> Vec<PathBuf> {
             files.push(path)
         } else if path.is_dir() {
             for file in get_files(&path) {
-                files.push(file.into())
+                files.push(file)
             }
         }
     }


### PR DESCRIPTION
This fixes the build of the examples on a current stable toolchain and adds a `no_std` feature, that replaces the `HashMap` with a [`heapless::FnvIndexMap`](https://docs.rs/heapless/0.8.0/heapless/type.FnvIndexMap.html), so that it can be used in embedded projects as well.